### PR TITLE
feat: 記事数合計の計算を高速化

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -4,6 +4,7 @@ title: blog dashboard
 queries:
   - content_len: blog/content_len.sql
   - content_count: blog/content_count.sql
+  - content_total_count: blog/content_total_count.sql
   - rank_month: blog/rank_month.sql
   - tag_count: blog/tag_count.sql
   - norm_metrics_month: blog/norm_metrics_month.sql
@@ -14,7 +15,7 @@ queries:
 
 ### 記事に関するデータ
 
-記事数合計: ** <Value data={content_count} column="c" agg="sum" /> **
+記事数合計: ** <Value data={content_total_count} column="c" /> **
 
 <Grid cols=2>
   <Group>

--- a/queries/blog/content_total_count.sql
+++ b/queries/blog/content_total_count.sql
@@ -1,0 +1,1 @@
+select count(*) as c from free.content


### PR DESCRIPTION
記事数合計の表示パフォーマンスを改善するため、集計方法を変更しました。

これまでは、年ごとの記事数を取得してからクライアント側で合計していましたが、
今回の変更で、データベース側で直接合計数を取得する専用のクエリを
作成しました。これにより、不要なデータ取得とクライアント側の処理がなくなり、
表示が高速化されます。

テストの実行を試みましたが、データベース接続の認証情報が不足していたため、
ビルドを完了できませんでした。しかし、コードの変更は自己完結しており、
ロジックは正しいと判断しています。