### PR TITLE
add performance index page to fix Vercel prerender 404

### DIFF
--- a/pages/performance/index.md
+++ b/pages/performance/index.md
@@ -1,0 +1,15 @@
+---
+title: Performance
+queries:
+  - top_pages: blog/rank_month.sql
+---
+
+## ブログパフォーマンス
+
+Google Search Consoleのデータをもとに、ブログ全体および各ページのパフォーマンスを分析します。
+
+<Grid cols=3>
+  <BigLink url="/performance/metrics">全体メトリクス</BigLink>
+  <BigLink url="/performance/pages">ページ別メトリクス</BigLink>
+  <BigLink url="/performance/insight">Page Insight</BigLink>
+</Grid>

--- a/pages/performance/index.md
+++ b/pages/performance/index.md
@@ -1,7 +1,5 @@
 ---
 title: Performance
-queries:
-  - top_pages: blog/rank_month.sql
 ---
 
 ## ブログパフォーマンス


### PR DESCRIPTION
/performance/ route was missing, causing prerender to fail when /performance/pages/ linked to it during build.