### PR TITLE
Filter unsafe performance slugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ static/data
 *.log
 .vercel
 .env*.local
+.worktrees/

--- a/pages/performance/pages.md
+++ b/pages/performance/pages.md
@@ -8,6 +8,9 @@ select
     '/performance/' || slug as link,
     sum(impressions) as i
 from free.count_search_word
+where
+    slug is not null
+    and regexp_matches(slug, '^[A-Za-z0-9][A-Za-z0-9._~-]*$')
 group by all
 order by i desc
 ```


### PR DESCRIPTION
## Summary
- Filter performance page links to URL-path-safe slugs only
- Ignore generated worktrees via .gitignore

## Verification
- Not run per request; user will verify locally